### PR TITLE
Update roq.cpp

### DIFF
--- a/engines/groovie/video/roq.cpp
+++ b/engines/groovie/video/roq.cpp
@@ -496,7 +496,7 @@ bool ROQPlayer::processBlock() {
 	}
 
 	// Calculate where the block should end
-	int32 endpos = _file->pos() + blockHeader.size;
+	int64 endpos = _file->pos() + blockHeader.size;
 
 	// Detect the end of the video
 	if (_file->eos()) {
@@ -547,7 +547,7 @@ bool ROQPlayer::processBlock() {
 	if (endpos != _file->pos()) {
 		warning("Groovie::ROQ: BLOCK %04x Should have ended at %d, and has ended at %d", blockHeader.type, endpos, (int)_file->pos());
 		warning("Ensure you've copied the files correctly according to the wiki.");
-		_file->seek(endpos);
+		_file->seek(MIN(_file->pos(),endpos));
 	}
 	// End the frame when the graphics have been modified or when there's an error
 	return endframe || !ok;


### PR DESCRIPTION
GROOVIE: Fix bug - https://bugs.scummvm.org/ticket/13809
In case of endpos not equal to _file->pos we should take minimum to be sure that we won't exceed maximum size and didn't fail on assertion